### PR TITLE
Update Go version to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/khaldeezal/Finplan-structure
 
-go 1.24.3
+go 1.22

--- a/services/api-gateway/go.mod
+++ b/services/api-gateway/go.mod
@@ -1,6 +1,6 @@
 module github.com/khaldeezal/Finplan-structure/services/api-gateway
 
-go 1.24.3
+go 1.22
 
 require (
 	github.com/gin-gonic/gin v1.10.1

--- a/services/auth-service/go.mod
+++ b/services/auth-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/khaldeezal/Finplan-structure/services/auth-service
 
-go 1.24.3
+go 1.22
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/services/transaction-service/go.mod
+++ b/services/transaction-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/khaldeezal/Finplan-structure/services/transaction-service
 
-go 1.24.3
+go 1.22
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/services/user-service/go.mod
+++ b/services/user-service/go.mod
@@ -1,6 +1,6 @@
 module github.com/khaldeezal/Finplan-structure/services/user-service
 
-go 1.24.3
+go 1.22
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2


### PR DESCRIPTION
## Summary
- set `go 1.22` in the root module and all services

## Testing
- `go mod tidy` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840800875d483258610bf0fc7498a5c